### PR TITLE
Feat: added neo4j driver configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ import { Neo4jModule } from 'nest-neo4j'
       host: 'localhost',
       port: 7687,
       username: 'neo4j',
-      password: 'neo',
-      disableLosslessIntegers: false,
+      password: 'neo'
     })
   ],
   controllers: [AppController],

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ import { Neo4jModule } from 'nest-neo4j'
       host: 'localhost',
       port: 7687,
       username: 'neo4j',
-      password: 'neo'
+      password: 'neo',
+      disableLosslessIntegers: false,
     })
   ],
   controllers: [AppController],

--- a/src/interfaces/neo4j-config.interface.ts
+++ b/src/interfaces/neo4j-config.interface.ts
@@ -7,4 +7,5 @@ export interface Neo4jConfig {
     username: string;
     password: string;
     database?: string;
+    disableLosslessIntegers?: boolean;
 }

--- a/src/interfaces/neo4j-config.interface.ts
+++ b/src/interfaces/neo4j-config.interface.ts
@@ -1,3 +1,4 @@
+import { types } from "neo4j-driver-core";
 export type Neo4jScheme = 'neo4j' | 'neo4j+s' | 'neo4j+scc' | 'bolt' | 'bolt+s' | 'bolt+scc'
 
 export interface Neo4jConfig {
@@ -7,5 +8,5 @@ export interface Neo4jConfig {
     username: string;
     password: string;
     database?: string;
-    disableLosslessIntegers?: boolean;
+    options?: types.Config;
 }

--- a/src/neo4j.utils.ts
+++ b/src/neo4j.utils.ts
@@ -5,7 +5,7 @@ export const createDriver = async (config: Neo4jConfig) => {
     const driver = neo4j.driver(
         `${config.scheme}://${config.host}:${config.port}`,
         neo4j.auth.basic(config.username, config.password),
-        { disableLosslessIntegers: config.disableLosslessIntegers || false }
+        config.options
     )
 
     await driver.verifyConnectivity()

--- a/src/neo4j.utils.ts
+++ b/src/neo4j.utils.ts
@@ -4,7 +4,8 @@ import { Neo4jConfig } from './interfaces/neo4j-config.interface'
 export const createDriver = async (config: Neo4jConfig) => {
     const driver = neo4j.driver(
         `${config.scheme}://${config.host}:${config.port}`,
-        neo4j.auth.basic(config.username, config.password)
+        neo4j.auth.basic(config.username, config.password),
+        { disableLosslessIntegers: config.disableLosslessIntegers || false }
     )
 
     await driver.verifyConnectivity()


### PR DESCRIPTION
## Added 
Added a neo4j driver configuration option to only return native integer numbers instead of custom integer object.

## Premise
This feature enables configuring driver object to return native integer numbers instead of custom integer object ({low, high}). The configuration option affects all the integers returned by the driver.

## Reference 
https://github.com/neo4j/neo4j-javascript-driver#reading-integers - has proper documentation, which I have referred for implementation.
 
## Changes
- Introduced configuration option in src/neo4j.utils.ts
- Introduced disableLosslessIntegers in src/interfaces/neo4j-config.interface.ts
- Added configuration option in README.md

@adam-cowley  kindly verify the code and I am looking forward to your response.